### PR TITLE
fix(knext): remove peft reference to avoid a huge install package

### DIFF
--- a/python/nn4k/requirements.txt
+++ b/python/nn4k/requirements.txt
@@ -1,3 +1,2 @@
 openai
 json5
-peft>=0.5.0


### PR DESCRIPTION
remove peft reference to avoid a huge install package(will install torch, transformer and so on...)