### PR TITLE
fix(cloudext): do not JSON-encode scalar String property values

### DIFF
--- a/cloudext/interface/graph-store/src/main/java/com/antgroup/openspg/cloudext/interfaces/graphstore/util/TypeChecker.java
+++ b/cloudext/interface/graph-store/src/main/java/com/antgroup/openspg/cloudext/interfaces/graphstore/util/TypeChecker.java
@@ -42,12 +42,18 @@ public class TypeChecker {
         || clazz.equals(Short.class)
         || clazz.equals(Byte.class)
         || clazz.equals(Boolean.class)
-        || clazz.equals(Character.class);
+        || clazz.equals(Character.class)
+        || clazz.equals(String.class);
   }
 
   public static boolean isArrayOrCollectionOfPrimitives(Object obj) {
     if (obj == null) {
       return false;
+    }
+    if (obj instanceof String) {
+      // scalar strings must be stored as-is: JSON-encoding them adds surrounding
+      // quotes (e.g. 102191 -> "102191"), which breaks numeric coercion at read time
+      return true;
     }
     if (obj instanceof Object[]) {
       for (Object element : (Object[]) obj) {


### PR DESCRIPTION
## Symptom

After ingesting data through the local builder (e.g. the supplychain example), every property value except `id`/`name` is stored in Neo4j double-encoded with surrounding quotes, e.g. `transAmt` = `"102191"` instead of `102191`.

Because the reasoner reads raw property values, numeric functions in concept rules (`sum`, `date_diff`, ...) silently match 0 rows on such values, so all rule-derived virtual properties (e.g. `fundTrans1Month`) resolve to `null`. Returning the value directly raises:

```
NumberFormatException: For input string: "\"102191\""
```

## Root cause

`Neo4jSinkWriter.writeNode/writeEdge` JSON-encode any value for which `TypeChecker.isArrayOrCollectionOfPrimitives()` returns `false`. That check returns `false` for scalar strings, and `String` is also missing from `isPrimitiveOrWrapper()`, so every string property gets passed through `JSON.toJSONString()` and picks up an extra pair of quotes. The write side and the read side (reasoner expects raw values) are asymmetric.

## Fix

Treat scalar strings as storable as-is, and accept `String` elements inside arrays/collections for the same reason. Two lines in `TypeChecker`.

## Verification

Applied this change to a running 0.8 server (hot-patched jar), rebuilt the supplychain example: all properties are stored clean, and concept rules computing over numeric string fields (fund transaction aggregates) produce correct non-null values.
