### PR TITLE
fix(reasoner): store business id as property on DDL-created vertices

### DIFF
--- a/reasoner/runner/runner-common/src/main/java/com/antgroup/openspg/reasoner/rdg/common/ExtractVertexImpl.java
+++ b/reasoner/runner/runner-common/src/main/java/com/antgroup/openspg/reasoner/rdg/common/ExtractVertexImpl.java
@@ -75,8 +75,9 @@ public class ExtractVertexImpl implements Serializable {
       vertexProps.put(propertyName, value);
     }
     IVertexId vertexId;
+    String bizId;
     if (vertexProps.containsKey("id")) {
-      vertexId = IVertexId.from(String.valueOf(vertexProps.get("id")), this.type);
+      bizId = String.valueOf(vertexProps.get("id"));
     } else {
       StringBuilder vertexIdSb = new StringBuilder();
       List<String> aliasList = Lists.newArrayList(kgGraph.getVertexAlias());
@@ -84,10 +85,15 @@ public class ExtractVertexImpl implements Serializable {
       for (String vertexAlias : aliasList) {
         vertexIdSb.append(kgGraph.getVertex(vertexAlias).get(0).getId());
       }
-      vertexId = IVertexId.from(vertexIdSb.toString(), this.type);
+      bizId = vertexIdSb.toString();
     }
+    vertexId = IVertexId.from(bizId, this.type);
     IVertex<IVertexId, IProperty> willAddedVertex =
         new Vertex<>(vertexId, getVertexProperty(vertexId, this.version, context));
+    // DDL-created vertices must carry their business id as the "id" property; a
+    // follow-up rule run that uses this vertex as a start id would otherwise die
+    // with an NPE in LocalRDG.generateStartNodeDebugInfo (get("id").toString())
+    willAddedVertex.getValue().put("id", bizId);
 
     Map<String, Set<IVertex<IVertexId, IProperty>>> alias2VertexMap = new HashMap<>();
     alias2VertexMap.put(this.alias, Sets.newHashSet(willAddedVertex));


### PR DESCRIPTION
## Symptom

Events created by a concept rule's Action block (`createNodeInstance`) never receive their `belongTo` classification, and concept-level propagation over them silently stops. No error is visible in `docker logs` or in the client response — the exception only appears in the server's `common-error.log`.

## Root cause

`ExtractVertexImpl.extractVertex()` computes a business id for the new vertex (either from the `id` entry in the Action's value map, or by concatenating the internal ids of all pattern-bound vertices) but only uses it to build the internal `IVertexId`. The vertex property map never gets an `id` entry.

Any subsequent rule execution that uses such a vertex as a start id then crashes while assembling debug info:

```
java.lang.NullPointerException
  at LocalRDG.generateStartNodeDebugInfo(LocalRDG.java:1461)   // get("id").toString()
  at LocalRDG.getResult(LocalRDG.java:1470)
  at LocalReasonerRunner.doRun
  at InductiveConceptReasoner.reason
  at CausalConceptReasoner.propagate
```

`LocalReasonerRunner.run()` catches all Throwables and returns an empty result, so the caller treats the failed run as "0 matches": generated events lose their `belongTo` classification and causal propagation stops.

## Fix

Preserve the computed business id and store it in the vertex property map, matching the shape of vertices loaded from the warehouse.

## Verification

Reproduced with the supplychain example (0.8 server): rule ④ (price rise → cost rise) creates 47 CompanyEvent vertices; before the fix all 47 follow-up classification runs died with the NPE above (47 entries in common-error.log, 0 belongTo edges). After the fix: 0 NPEs, 47/47 belongTo edges.
